### PR TITLE
chore: add Jira support [OFY25-3]

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,19 +34,19 @@ To run the Jira version of this script, you need a [Jira personal access token](
 
 For GitHub markdown formatting, run it with:
 
-    npm run release-notes-jira <jira project key> <jira label>
+    npm run release-notes-jira <jira project key> <jira fix version>
 
 Example:
 
-    npm run release-notes-jira LARA v5.0.0
+    npm run release-notes-jira LARA "LARA v5.0.0"
 
 For Slack markdown formatting, run it with:
 
-    npm run release-notes-jira <jira project key> <jira label> slack
+    npm run release-notes-jira <jira project key> <jira fix version> slack
 
 Example:
 
-    npm run release-notes-jira LARA v5.0.0 slack
+    npm run release-notes-jira LARA "LARA v5.0.0" slack
 
 ## Release Status
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,21 @@ For Slack markdown formatting, run it with:
 
     npm run release-notes <pt label> slack
 
+### Jira Version
+
+To run the Jira version of this script, you need a [Jira personal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). Add the token to a `.env` file in the scripts folder with
+
+    JIRA_TOKEN=<token>
+    JIRA_USER=<your jira account email address>
+
+For GitHub markdown formatting, run it with:
+
+    npm run release-notes-jira <jira project key> <jira label>
+
+For Slack markdown formatting, run it with:
+
+    npm run release-notes-jira <jira project key> <jira label> slack
+
 ## Release Status
 
 This uses Pivotal Tracker and GitHub to find the stories and PRs related to the release. To run it you'll need a token from Pivotal and a token from GitHub. You can make a GitHub fine grain access token so it can't be abused or a just use a regular GitHub token. If you use a fine grain token, it has to have permission to read the repository content and the pull requests.  

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,9 +36,17 @@ For GitHub markdown formatting, run it with:
 
     npm run release-notes-jira <jira project key> <jira label>
 
+Example:
+
+    npm run release-notes-jira LARA v5.0.0
+
 For Slack markdown formatting, run it with:
 
     npm run release-notes-jira <jira project key> <jira label> slack
+
+Example:
+
+    npm run release-notes-jira LARA v5.0.0 slack
 
 ## Release Status
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,9 +66,9 @@ https://github.com/concord-consortium/collaborative-learning/compare/<base>...<h
 
 To use this to check a release you'll want to use the previous release tag as the base.
 
-### Jira Version
+## Unlinked PRs
 
-The Jira version of this script will only list all PRs that have been merged in since the last release that don't have a linked Jira issue. All other information provided by the PT version can be found in a project's Releases view in the Jira UI.
+Lists all PRs that have been merged in since the last release that don't have a linked Jira issue.
 
 To run the script, you need a [Jira personal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). Add the token to a `.env` file in the scripts folder with
 
@@ -81,11 +81,11 @@ You'll also need to add a GitHub token. You can make a GitHub fine grain access 
 
 Run the script with
 
-    npm run release-status-jira <jira project key> <jira fix version> <github repo> <base ref> <head ref>
+    npm run unlinked-prs <jira project key> <jira fix version> <github repo> <base ref> <head ref>
 
 Example:
 
-    npm run release-status-jira LARA "LARA v5.0.0" lara v4.9.1 v5.0.0
+    npm run unlinked-prs LARA "LARA v5.0.0" lara v4.9.1 v5.0.0
 
 The base and head refs are the same that would be used here in a github compare link. Like: 
 https://github.com/concord-consortium/collaborative-learning/compare/<base>...<head>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,6 +66,32 @@ https://github.com/concord-consortium/collaborative-learning/compare/<base>...<h
 
 To use this to check a release you'll want to use the previous release tag as the base.
 
+### Jira Version
+
+The Jira version of this script will only list all PRs that have been merged in since the last release that don't have a linked Jira issue. All other information provided by the PT version can be found in a project's Releases view in the Jira UI.
+
+To run the script, you need a [Jira personal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). Add the token to a `.env` file in the scripts folder with
+
+    JIRA_TOKEN=<token>
+    JIRA_USER=<your jira account email address>
+
+You'll also need to add a GitHub token. You can make a GitHub fine grain access token so it can't be abused or a just use a regular GitHub token. If you use a fine grain token, it has to have permission to read the repository content and the pull requests.
+
+    GITHUB_TOKEN=<token>
+
+Run the script with
+
+    npm run release-status-jira <jira project key> <jira fix version> <github repo> <base ref> <head ref>
+
+Example:
+
+    npm run release-status-jira LARA "LARA v5.0.0" lara v4.9.1 v5.0.0
+
+The base and head refs are the same that would be used here in a github compare link. Like: 
+https://github.com/concord-consortium/collaborative-learning/compare/<base>...<head>
+
+To use this to check a release you'll want to use the previous release tag as the base.
+
 ### Unsupported Workflow
 When a PR's changes are merged into the main/master branch and it also merged into a version branch. In this case, the story needs to be labeled with both releases so that it doesn't show up in the release status "missing PR" list. However this means the story will then show up in the release notes for both releases. Since the release notes are supposed to just list new things, this isn't accurate. 
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,11 +12,11 @@
     "release-notes": "node release-notes.mjs",
     "release-notes-jira": "node release-notes-jira.mjs",
     "release-status": "node release-status.mjs",
-    "release-status-jira": "node release-status-jira.mjs",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test-github": "node test-github.mjs",
     "test-pivotal": "node test-pivotal.mjs",
-    "test-jira": "node test-jira.mjs"
+    "test-jira": "node test-jira.mjs",
+    "unlinked-prs": "node unlinked-prs.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,6 +12,7 @@
     "release-notes": "node release-notes.mjs",
     "release-notes-jira": "node release-notes-jira.mjs",
     "release-status": "node release-status.mjs",
+    "release-status-jira": "node release-status-jira.mjs",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test-github": "node test-github.mjs",
     "test-pivotal": "node test-pivotal.mjs",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,10 +10,12 @@
   },
   "scripts": {
     "release-notes": "node release-notes.mjs",
+    "release-notes-jira": "node release-notes-jira.mjs",
     "release-status": "node release-status.mjs",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test-github": "node test-github.mjs",
-    "test-pivotal": "node test-pivotal.mjs"
+    "test-pivotal": "node test-pivotal.mjs",
+    "test-jira": "node test-jira.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/release-notes-jira.mjs
+++ b/scripts/release-notes-jira.mjs
@@ -25,6 +25,15 @@ if (!jiraUser || !jiraToken) {
   process.exit(1);
 }
 
+const jiraProjectKey = process.argv[2];
+const jiraLabel = process.argv[3];
+const slack = process.argv?.[4];
+
+if (!jiraProjectKey || !jiraLabel) {
+  console.error("Both a Jira project key and a Jira label value are required.\n\nUsage:\n\n`npm run release-notes-jira LARA lara-5.0.0` or\n`node release-notes-jira.mjs LARA lara-5.0.0`\n");
+  process.exit(1);
+}
+
 const features = [];
 const bugs = [];
 const underTheHood = [];
@@ -66,9 +75,6 @@ async function collectStories(projectKey, search) {
   }
 }
 
-const jiraProjectKey = process.argv[2];
-const jiraLabel = process.argv[3];
-const slack = process.argv?.[4];
 await collectStories(jiraProjectKey, jiraLabel);
 
 function storyText(story) {

--- a/scripts/release-notes-jira.mjs
+++ b/scripts/release-notes-jira.mjs
@@ -1,0 +1,113 @@
+/**
+ * Generates release notes from completed Jira stories and bugs.
+ * 
+ * Required command-line parameters:
+ * - Jira project key (e.g., "LARA")
+ * - Jira label for filtering stories (e.g., "lara-5.0.0")
+ * 
+ * Optional command-line parameters:
+ * - "slack" to format output for Slack
+ * 
+ * Example usage:
+ * node release-notes-jira.mjs LARA lara-5.0.0 slack
+ */
+
+import "dotenv/config"
+import fetch from "node-fetch";
+import querystring from "querystring";
+import { extractBlurbText, jiraApiBaseUrl, jiraRequestHeaders } from "./utils.mjs";
+
+const jiraUser = process.env.JIRA_USER;
+const jiraToken = process.env.JIRA_TOKEN;
+
+if (!jiraUser || !jiraToken) {
+  console.error("Both the JIRA_USER and JIRA_TOKEN environment variables are required.");
+  process.exit(1);
+}
+
+const features = [];
+const bugs = [];
+const underTheHood = [];
+
+function isUnderTheHood(story) {
+  return story.fields.labels.find(label => label === "under-the-hood");
+}
+
+async function collectStories(projectKey, search) {
+  const fields = ["id", "summary", "issuetype", "description", "labels"].join(",");
+  const jql = `project=${projectKey} AND issuetype in (Story, Bug) AND status in (Done, Closed) AND labels in (${search})`;
+  const urlQuery = querystring.stringify({
+    jql,
+    fields,
+    maxResults: 100
+  });
+  const url = `${jiraApiBaseUrl}/search?${urlQuery}`;
+  const requestHeaders = jiraRequestHeaders(jiraUser, jiraToken);
+  const response = await fetch(url, requestHeaders);
+  const json = await response.json();
+  const stories = json.issues;
+
+  if (stories.length === 0) {
+    console.error(`No stories found for project ${projectKey} with label ${search}`);
+    process.exit(1);
+  }
+
+  for (const story of stories) {
+    if (isUnderTheHood(story)) {
+      underTheHood.push(story);
+    } else {
+      if (story.fields.issuetype.name === "Story") {
+        features.push(story);
+      }
+      if (story.fields.issuetype.name === "Bug") {
+        bugs.push(story);
+      }  
+    }
+  }
+}
+
+const jiraProjectKey = process.argv[2];
+const jiraLabel = process.argv[3];
+const slack = process.argv?.[4];
+await collectStories(jiraProjectKey, jiraLabel);
+
+function storyText(story) {
+  const blurbText = extractBlurbText(story.fields.description.content);
+  if (blurbText) {
+    return blurbText;
+  }
+  return story.fields.summary.trim();
+}
+
+function storyItem(story) {
+  const text = storyText(story);
+  return slack 
+    ? `*[${story.key}](${jiraApiBaseUrl}/browse/${story.key}):* ${text}` 
+    : `**${story.key}:** ${text}`;
+}
+
+const prefix = slack ? '> ' : '';
+function print(msg) {
+  console.log(`${prefix}${msg}`);
+}
+function printHeader(msg) {
+  if (slack) {
+    print(`*${msg}*`);
+  } else {
+    print(`### ${msg}`);
+  }
+}
+
+function printSection(msg, stories) {
+  if (stories.length > 0) {
+    printHeader(msg);
+    for (const story of stories) {
+      print(`- ${storyItem(story)}`);
+    }
+    print("");
+  }  
+}
+
+printSection("✨ Features & Improvements:", features);
+printSection("🐞 Bug Fixes:", bugs);
+printSection("🛠 Under the Hood:", underTheHood);

--- a/scripts/release-status-jira.mjs
+++ b/scripts/release-status-jira.mjs
@@ -1,0 +1,145 @@
+/**
+ * Compiles a list of all PRs merged since the last release that do not have a linked Jira issue.
+ * 
+ * Required command-line parameters:
+ * - Jira project key (e.g., "LARA")
+ * - Jira fix version (e.g., "LARA v5.0.0")
+ * - GitHub repo name (e.g., "lara")
+ * - GitHub base ref (e.g., "v4.9.1")
+ * - GitHub head ref (e.g., "v5.0.0")
+ * 
+ * Example usage:
+ * node release-status-jira.mjs LARA "LARA v2.15.0" lara v4.9.1 v5.0.0
+ */
+
+import "dotenv/config";
+import fetch from "node-fetch";
+import querystring from "querystring";
+import { Octokit } from "@octokit/rest";
+import { jiraApiBaseUrl, jiraDevApiBaseUrl, jiraRequestHeaders } from "./utils.mjs";
+
+const jiraUser = process.env.JIRA_USER;
+const jiraToken = process.env.JIRA_TOKEN;
+const ghToken = process.env.GITHUB_TOKEN;
+
+if (!jiraUser || !jiraToken) {
+  console.error("Both the JIRA_USER and JIRA_TOKEN environment variables are required.");
+  process.exit(1);
+}
+
+if (!ghToken) {
+  console.error("GITHUB_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+const jiraProjectKey = process.argv[2];
+const jiraFixVersion = process.argv[3];
+const gitRepo = process.argv[4];
+const gitBase = process.argv[5];
+const gitHead = process.argv[6];
+
+const octokit = new Octokit({ auth: ghToken });
+
+async function getJiraLinkedPRs() {
+  const urlQuery = querystring.stringify({
+    jql: `project=${jiraProjectKey} AND fixVersion in ("${jiraFixVersion}") AND issuetype in (Story, Bug, Chore)`,
+    maxResults: 100
+  });
+
+  const url = `${jiraApiBaseUrl}/search?${urlQuery}`;
+  const requestHeaders = jiraRequestHeaders(jiraUser, jiraToken);
+  const response = await fetch(url, requestHeaders);
+  const json = await response.json();
+  const jiraPRs = new Set();
+
+  await Promise.all(json.issues.map(async (issue, index) => {
+    try {
+      const prUrl = `${jiraDevApiBaseUrl}/issue/detail?issueId=${issue.id}&applicationType=GitHub&dataType=pullrequest`;
+      const prResponse = await fetch(prUrl, requestHeaders);
+      const prData = await prResponse.json();
+
+      if (Array.isArray(prData.detail) && prData.detail.length > 0) {
+        prData.detail[0].pullRequests.forEach(storyPr => {
+          const match = storyPr.id.match(/\d+/);
+          if (match) {
+            const prNumber = parseInt(match[0], 10);
+            jiraPRs.add(prNumber);
+          } else {
+            console.warn(`Skipping invalid PR ID format (${storyPr.id}) for issue ${issue.key} with title ${issue.fields.summary}`);
+          }
+        });
+      }
+    } catch (error) {
+      console.error(`Error fetching PRs for Jira issue ${issue.key}:`, error);
+    }
+  }));
+
+  return jiraPRs;
+}
+
+async function getMergedPRs() {
+  const commits = await octokit.paginate(
+    octokit.repos.compareCommits,
+    {
+      owner: "concord-consortium",
+      repo: gitRepo,
+      base: gitBase,
+      head: gitHead
+    },
+    response => response.data.commits.map(commit => ({
+      sha: commit.sha,
+      date: commit.commit.author.date
+    }))
+  );
+
+  if (!commits.length) {
+    console.log("No commits found");
+    process.exit(0);
+  }
+
+  const mergeBaseCommitDate = commits[0].date;
+
+  const prs = await octokit.paginate(
+    octokit.pulls.list,
+    {
+      owner: "concord-consortium",
+      repo: gitRepo,
+      state: "closed",
+      sort: "updated",
+      direction: "desc"
+    },
+    (response) => {
+      return response.data
+        .filter(pr => pr.merged_at && pr.merged_at > mergeBaseCommitDate)
+        .map(pr => ({
+          number: pr.number,
+          merged_at: pr.merged_at,
+          html_url: pr.html_url,
+          title: pr.title,
+          user: pr.user.login
+        }));
+    }
+  );
+
+  return prs;
+}
+
+async function getUnlinkedMergedPRs() {
+  const [jiraPRs, mergedPRs] = await Promise.all([
+    getJiraLinkedPRs(),
+    getMergedPRs()
+  ]);
+
+  const unlinkedPRs = mergedPRs.filter(pr => !jiraPRs.has(pr.number));
+
+  console.log(`\n🔎 PRs Merged Since Last Release Without a Linked Jira Issue:\n`);
+  if (unlinkedPRs.length === 0) {
+    console.log("✅ No untracked PRs found.");
+  } else {
+    unlinkedPRs.forEach(pr => {
+      console.log(`❌ ${pr.html_url} - ${pr.title} (by ${pr.user})`);
+    });
+  }
+}
+
+getUnlinkedMergedPRs();

--- a/scripts/test-jira.mjs
+++ b/scripts/test-jira.mjs
@@ -1,0 +1,22 @@
+import "dotenv/config";
+import fetch from "node-fetch";
+import { extractBlurbText, jiraApiBaseUrl, jiraRequestHeaders } from "./utils.mjs";
+
+const jiraUser = process.env.JIRA_USER;
+const jiraToken = process.env.JIRA_TOKEN;
+
+if (!jiraUser || !jiraToken) {
+  console.error("Both the JIRA_USER and JIRA_TOKEN environment variables are required.");
+  process.exit(1);
+}
+
+const url = `${jiraApiBaseUrl}/issue/WEB-2`
+const requestHeaders = jiraRequestHeaders(jiraUser, jiraToken);
+const response = await fetch(url, requestHeaders);
+
+const json = await response.json();
+console.log(json);
+
+const blurbMatch = extractBlurbText(json.fields.description.content);
+const description = blurbMatch ?? json.fields.summary.trim();
+console.log(description);

--- a/scripts/unlinked-prs.mjs
+++ b/scripts/unlinked-prs.mjs
@@ -9,7 +9,7 @@
  * - GitHub head ref (e.g., "v5.0.0")
  * 
  * Example usage:
- * node release-status-jira.mjs LARA "LARA v2.15.0" lara v4.9.1 v5.0.0
+ * node unlinked-prs.mjs LARA "LARA v5.0.0" lara v4.9.1 v5.0.0
  */
 
 import "dotenv/config";

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,4 +1,5 @@
 export const jiraApiBaseUrl = "https://concord-consortium.atlassian.net/rest/api/3";
+export const jiraDevApiBaseUrl = "https://concord-consortium.atlassian.net/rest/dev-status/1.0";
 
 export function extractBlurbText(contentArray) {
   for (const paragraph of contentArray) {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,0 +1,22 @@
+export const jiraApiBaseUrl = "https://concord-consortium.atlassian.net/rest/api/3";
+
+export function extractBlurbText(contentArray) {
+  for (const paragraph of contentArray) {
+    if (!paragraph.content) continue;
+
+    if (paragraph.content[0]?.text?.trim() === "Blurb:") {
+      return paragraph.content.slice(1).map(item => item.text).join("").trim();
+    }
+  }
+  return null;
+}
+
+export function jiraRequestHeaders (jiraUser, jiraToken) {
+  const authHeader = `Basic ${Buffer.from(`${jiraUser}:${jiraToken}`).toString("base64")}`;
+  return {
+    headers: {
+    "Authorization": authHeader,
+    "Accept": "application/json"
+    }
+  };
+}


### PR DESCRIPTION
[OFY25-3](https://concord-consortium.atlassian.net/browse/OFY25-3)

Adds a `release-notes-jira.mjs` script for gathering completed story and bug issues from Jira for release notes. The script differs from the existing `release-notes.mjs` for Pivotal Tracker in that a project key needs to be specified in the command when running it. I think that makes sense for Jira since there we have a board for each project instead of team boards like we do in PT. Also, making a separate script for Jira seemed like the most straightforward approach since PT is being retired. Once the migration from PT is complete, `release-notes-jira.mjs` could become `release-notes.mjs`.



[OFY25-3]: https://concord-consortium.atlassian.net/browse/OFY25-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ