### PR TITLE
use commit SHAs to find the merged PRs

### DIFF
--- a/CLUE-release-steps.md
+++ b/CLUE-release-steps.md
@@ -1,10 +1,18 @@
-- check the status of the release with release-status:
-  `npm run release-status clue-[new_version] collaborative-learning v[old_version] master`
-- make and checkout release branch
-- run `npm version x.y.z` in release branch
-- push branch and tag
+- check the status of the release in Jira: 
+  - navigate to: https://concord-consortium.atlassian.net/projects/CLUE?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page
+  - click on the version of the release
+  - all stories should be done
+  - there should be no "warnings" on the right side. I believe that would indicate if an issue has a PR that is not merged.
+- check for PRs that have been merged but are not associated with any Jira issues:
+  `npm run unlinked-prs CLUE <new version in jira> collaborative-learning <tag of previous version in GitHub> master`
+- create and checkout a new release branch usually `vA.B.x` where A and B are numbers
+- run `npm version A.B.C` in release branch where C is the patch number. This does 3 things:
+  - it updates package.json and package-lock.json with the new version
+  - it commits these changes with a message of `A.B.C`
+  - it creates a tag of `vA.B.C`
+- push the `vA.B.x` branch and `vA.B.C` tag
 - generate release notes:
-  `npm run release-notes clue-[new_version]`
+  `npm run release-notes-jira CLUE <new version in jira>`
 - add release notes to GitHub
 - update learn.portal.staging.concord.org:
   - report: https://learn.portal.staging.concord.org/admin/external_reports/10/edit
@@ -17,7 +25,7 @@
 
 
 Streamline Tasks:
-- have tag building get the version from the tag instead of package.json, then we don't need to update the package.json
+- have the CLUE build system get the version from the tag instead of package.json, then we don't need to update the package.json
 - make a `prep-release` script which:
   - takes: <app-name> <previous-version> <version>
   - prints the release status using a lookup from app-name to repository
@@ -44,6 +52,12 @@ So with these changes the process would be:
 - wait for review by QA
 - run `do-release` script
 
-This could be further streamlined if the `prep-release` was able to start a GitHub workflow which required approval. And then it requires a date/time param. This would eleminate the "wait" step, and QA just has to approve the release, at which point it would automatically go out.
+With our new use of Jira these scripts could be integrated into a Jira release by creating a "release" issue in each Jira version. Jira issue types can have manual triggers added to them. I think these show up as links or buttons on the issue. This "release" issue can also have a custom field for the "previous version". 
 
+There could be a trigger which would run the unlinked-prs script and add new issues for each PR that was merged without a Jira issue. After running this script the Jira release status page would show these new issues so we can see there is something to be resolved to get complete release notes.
 
+There could be a prep-release trigger matching the prep-release script described above. 
+
+There could be a do-release trigger matching the do-release script described above. 
+
+I think with this setup then a QA engineer or product manager can do the release without needing to run any local scripts.


### PR DESCRIPTION
This also updates the CLUE-release-steps.
This CLUE-release-steps file should be moved out of this repository, but until the release process settles down it is useful to have next to the scripts.