### PR TITLE
fix: Story links in Jira release notes [DEV-82]

### DIFF
--- a/scripts/release-notes-jira.mjs
+++ b/scripts/release-notes-jira.mjs
@@ -15,7 +15,7 @@
 import "dotenv/config"
 import fetch from "node-fetch";
 import querystring from "querystring";
-import { extractBlurbText, jiraApiBaseUrl, jiraRequestHeaders } from "./utils.mjs";
+import { extractBlurbText, jiraBaseUrl, jiraApiBaseUrl, jiraRequestHeaders } from "./utils.mjs";
 
 const jiraUser = process.env.JIRA_USER;
 const jiraToken = process.env.JIRA_TOKEN;
@@ -88,7 +88,7 @@ function storyText(story) {
 function storyItem(story) {
   const text = storyText(story);
   return slack
-    ? `*[${story.key}](${jiraApiBaseUrl}/browse/${story.key}):* ${text}`
+    ? `*[${story.key}](${jiraBaseUrl}/browse/${story.key}):* ${text}`
     : `**${story.key}:** ${text}`;
 }
 

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,5 +1,6 @@
-export const jiraApiBaseUrl = "https://concord-consortium.atlassian.net/rest/api/3";
-export const jiraDevApiBaseUrl = "https://concord-consortium.atlassian.net/rest/dev-status/1.0";
+export const jiraBaseUrl = "https://concord-consortium.atlassian.net";
+export const jiraApiBaseUrl = `${jiraBaseUrl}/rest/api/3`;
+export const jiraDevApiBaseUrl = `${jiraBaseUrl}/rest/dev-status/1.0`;
 
 export function extractBlurbText(contentArray) {
   for (const paragraph of contentArray) {


### PR DESCRIPTION
This changes the base url for the story link output in the Slack release notes from the api path to the homepage path for the CC Jira instance.